### PR TITLE
Use compiler-builtins `mem` feature instead of rlibc

### DIFF
--- a/megaton-crt0/Cargo.toml
+++ b/megaton-crt0/Cargo.toml
@@ -4,5 +4,4 @@ name = "megaton-crt0"
 version = "0.1.0"
 
 [dependencies]
-compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins" }
-rlibc = "1.0.0"
+compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins", features = ["mem"] }


### PR DESCRIPTION
Pretty small change, but that's one less dependency at least =P